### PR TITLE
Adding guards to include files in C++ code.

### DIFF
--- a/lib/asyncfatfs.h
+++ b/lib/asyncfatfs.h
@@ -5,6 +5,10 @@
 
 #include "fat_standard.h"
 
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
 typedef struct afatfsFile_t *afatfsFilePtr_t;
 
 typedef enum {
@@ -73,3 +77,8 @@ bool afatfs_isFull();
 
 afatfsFilesystemState_e afatfs_getFilesystemState();
 afatfsError_e afatfs_getLastError();
+
+#if defined(__cplusplus)
+}
+#endif
+

--- a/lib/fat_standard.h
+++ b/lib/fat_standard.h
@@ -33,6 +33,10 @@
 #define FAT_MAKE_DATE(year, month, day)     (day | (month << 5) | ((year - 1980) << 9))
 #define FAT_MAKE_TIME(hour, minute, second) ((second / 2) | (minute << 5) | (hour << 11))
 
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
 typedef enum {
     FAT_FILESYSTEM_TYPE_INVALID,
     FAT_FILESYSTEM_TYPE_FAT12,
@@ -121,3 +125,8 @@ bool fat_isDirectoryEntryTerminator(fatDirectoryEntry_t *entry);
 bool fat_isDirectoryEntryEmpty(fatDirectoryEntry_t *entry);
 
 void fat_convertFilenameToFATStyle(const char *filename, uint8_t *fatFilename);
+
+#if defined(__cplusplus)
+}
+#endif
+

--- a/lib/sdcard.h
+++ b/lib/sdcard.h
@@ -3,6 +3,10 @@
 #include <stdint.h>
 #include <stdbool.h>
 
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
 typedef struct sdcard_metadata_t {
     uint8_t manufacturerID;
     uint16_t oemID;
@@ -106,3 +110,8 @@ sdcardOperationStatus_e sdcard_endWriteBlocks();
  * Only required to be provided when using AFATFS_USE_INTROSPECTIVE_LOGGING.
  */
 void sdcard_setProfilerCallback(sdcard_profilerCallback_c callback);
+
+#if defined(__cplusplus)
+}
+#endif
+


### PR DESCRIPTION
Add `extern "C"` in the headers inside `lib` in case the headers are being included from C++ code.